### PR TITLE
Mention JDK7+ is needed to run Spark.

### DIFF
--- a/download.html
+++ b/download.html
@@ -48,7 +48,12 @@
 			<div class="contentText">
 				<div class="getting_started">
 				<h1 class="getting_started_head">Downloads</h1>
-				<div class="normal">!!! Spark version 1.1.1 is now available on maven central !!!</div>
+				<h2 class="getting_started_head_loads">Prerequisites</h2>
+				<div class="normal"><br />
+					Spark requires JDK7+.
+				</div>
+				<h2 class="getting_started_head_loads">Latest changes</h2>
+				<div class="normal"><br />!!! Spark version 1.1.1 is now available on maven central !!!</div>
 				<div class="normal">Latest version: 1.1.1</div>
                                 
 								<div class="normal">New features: ResponseTransformerRoutes and TemplateViewRoutes</div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,8 @@
 			<div class="contentText">
 				<div class="getting_started">
 				<h1 class="getting_started_head">Quick start</h1>
-				<div class="normal_text"><a href="download.html">Download</a> the spark lib and its dependencies (Or just add as maven dependency). Put in your classpath and you're ready to go.</div>
+				<div class="normal_text"><a href="download.html">Download</a> the spark lib and its dependencies (Or just add as maven dependency). Put in your classpath and you're ready to go (make sure you run Spark with JDK7+)
+				</div>
 				<pre>
             <code>
 import static spark.Spark.*;

--- a/readme.html
+++ b/readme.html
@@ -67,7 +67,7 @@
 				<div class="getting_started">
 				<h1 class="getting_started_head">Getting started</h1>
 				<div class="normal_text">
-				<a href="download.html">Download</a> the spark lib and its dependencies (Or, let maven do all that for you).
+				<a href="download.html">Download</a> the spark lib and its dependencies (Or, let maven do all that for you). Verify you run Spark with JDK7+.
 				Put in your classpath. Start coding:</div>
 				<pre>
             <code>


### PR DESCRIPTION
To avoid the unnecessary frustration caused by an UnsupportedClassVersionError, I thought mentioning that Spark requires JDK7+ would be nicer :-)