### PR TITLE
Change the link of examples to GitHub

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -552,7 +552,7 @@ at <a href="http://code.google.com/p/spark-java/downloads/list">google code</a>
 <h1 class="getting_started_head">Examples</h1>
 <div class="normal">
 Examples can be found on the project's page
-at <a href="http://code.google.com/p/spark-java/#Examples">google code</a>
+at <a href="https://github.com/perwendel/spark#examples">GitHub</a>
 </div>
 
 <div class="normal"></div>


### PR DESCRIPTION
Examples on Google Code is outdated
