### PR TITLE
Fix example code in README section

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -86,11 +86,11 @@ import static spark.Spark.*;
 public class HelloWorld {
 
    public static void main(String[] args) {
-      
-      get("/hello",(request, response) -> {
+
+      get("/hello", (request, response) -> {
          return "Hello World!";
-      };
-      
+      });
+
    }
 
 }


### PR DESCRIPTION
Small fix error in example code. It's required a parenthesis to avoid syntax error.
