### PR TITLE
removeAttribute takes one param (reported by Sebastien Migniot)

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -248,7 +248,7 @@ response.removeCookie(&quot;foo&quot;);                   // remove cookie</code
 <div class="code-snippet"><pre><code class="language-java">request.session(true)                            // create and return session
 request.session().attribute(&quot;user&quot;)              // Get session attribute &#x27;user&#x27;
 request.session().attribute(&quot;user&quot;, &quot;foo&quot;)       // Set session attribute &#x27;user&#x27;
-request.session().removeAttribute(&quot;user&quot;, &quot;foo&quot;) // Remove session attribute &#x27;user&#x27;
+request.session().removeAttribute(&quot;user&quot;) // Remove session attribute &#x27;user&#x27;
 request.session().attributes()                   // Get all session attributes
 request.session().id()                           // Get session id
 request.session().isNew()                        // Check is session is new


### PR DESCRIPTION
Reported by Sébastien Migniot

In his words:

On main site documentation, page
http://sparkjava.com/documentation.html

On the "Session" section, there is a typo error :
ERROR: request.session().removeAttribute("user", "foo") // Remove session attribute 'user'
BETTER: request.session().removeAttribute("user") // Remove session attribute 'user'

RATIONALE: according to https://github.com/perwendel/spark/blob/master/src/main/java/spark/Session.java there is only one argument
