### PR TITLE
correct the discription of request.uri() method

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -211,7 +211,7 @@ request.scheme();                 // &quot;http&quot;
 request.servletPath();            // the servlet path, e.g. /result.jsp
 request.session();                // session management
 request.splat();                  // splat (*) parameters
-request.uri();                    // the uri, e.g. &quot;http://example.com/foo&quot;
+request.uri();                    // the uri, e.g. &quot;/foo&quot;
 request.url();                    // the url. e.g. &quot;http://example.com/foo&quot;
 request.userAgent();              // user agent</code></pre></div>
     


### PR DESCRIPTION
I found a small mistaken, I guest it's caused by a copy-post operation, so just want to correct it.
